### PR TITLE
feat : jwt의존성설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,15 @@ dependencies {
 	// mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	//jwt
+	implementation 'com.auth0:java-jwt:4.0.0'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+
+	// JAX-B dependencies for JDK 9+
+	implementation "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
+	implementation "org.glassfish.jaxb:jaxb-runtime:2.3.2"
 
 	//스프링 시큐리티
 	implementation 'org.springframework.boot:spring-boot-starter-security'


### PR DESCRIPTION
## Description
feat : jwt의존성설정

## Main Features
**📃 전달 사항**
build.grade jwt의존성 설정이 사라져서 오류가 나서 추가함.
	
    //jwt
	implementation 'com.auth0:java-jwt:4.0.0'
	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'

	// JAX-B dependencies for JDK 9+
	implementation "jakarta.xml.bind:jakarta.xml.bind-api:2.3.2"
	implementation "org.glassfish.jaxb:jaxb-runtime:2.3.2"
