### PR TITLE
feat : Friend APi 구현

### DIFF
--- a/src/main/java/dwu/swcmop/trippacks/config/BaseResponseStatus.java
+++ b/src/main/java/dwu/swcmop/trippacks/config/BaseResponseStatus.java
@@ -24,7 +24,13 @@ public enum BaseResponseStatus {
      * 3000 : Response 오류
      */
     // Common
-    SAVE_BAG_FAIL(false, 3001, "가방 생성에 실패했습니다.");
+    SAVE_BAG_FAIL(false, 3001, "가방 생성에 실패했습니다."),
+    DELETE_FRIEND_FAIL(false, 3002, "친구 삭제에 실패했습니다."),
+    FRIEND_IS_EMPTY(false, 3003, "친구가 존재하지 않습니다."),
+    ADD_FRIEND_FAIL(false, 3004, "친구 추가에 실패했습니다."),
+    EXIST_FRIEND_FAIL(false, 3005, "친구 관계가 이미 존재합니다."),
+
+    ACCEPT_FRIEND_FAIL(false, 3006, "친구 수락에 실패했습니다.");
 
     private final boolean isSuccess;
     private final int code;

--- a/src/main/java/dwu/swcmop/trippacks/dto/FriendRequest.java
+++ b/src/main/java/dwu/swcmop/trippacks/dto/FriendRequest.java
@@ -1,0 +1,16 @@
+package dwu.swcmop.trippacks.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FriendRequest {
+    private Long userId;
+    private Long friendId;
+    private Boolean isFriend;
+}

--- a/src/main/java/dwu/swcmop/trippacks/dto/FriendResponse.java
+++ b/src/main/java/dwu/swcmop/trippacks/dto/FriendResponse.java
@@ -1,0 +1,18 @@
+package dwu.swcmop.trippacks.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FriendResponse {
+    private Long id;
+    private Long userId;
+    private Long friendId;
+    private String kakaoEmail;
+    private Boolean isFriend;
+}

--- a/src/main/java/dwu/swcmop/trippacks/entity/Friend.java
+++ b/src/main/java/dwu/swcmop/trippacks/entity/Friend.java
@@ -1,22 +1,36 @@
 package dwu.swcmop.trippacks.entity;
 
+import lombok.Data;
+
 import javax.persistence.*;
 
+@Data
 @Entity
 @Table(name = "friend")
 public class Friend {
     @Id
-    @Column(name = "friend_id")
+    @Column(name = "fid")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long friendId;
+    private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
-    private User user;
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "friend_id")
+    private Long friendId;
 
     @Column(name = "kakao_email")
     private String kakaoEmail;
 
     @Column(name = "is_friend")
     private Boolean isFriend;
+
+    public Friend() {
+    }
+
+    public Friend(Long userId, Long friendId, Boolean isFriend) {
+        this.userId = userId;
+        this.friendId = friendId;
+        this.isFriend = isFriend;
+    }
 }

--- a/src/main/java/dwu/swcmop/trippacks/repository/FriendRepository.java
+++ b/src/main/java/dwu/swcmop/trippacks/repository/FriendRepository.java
@@ -1,0 +1,19 @@
+package dwu.swcmop.trippacks.repository;
+import dwu.swcmop.trippacks.entity.Friend;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import javax.transaction.Transactional;
+import java.util.List;
+
+@Repository
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+    Friend findUserEntityByUserIdAndFriendId(Long userId, Long friendId);
+
+    List<Friend> findUserEntityByUserId(Long userId);
+
+}

--- a/src/main/java/dwu/swcmop/trippacks/service/FriendService.java
+++ b/src/main/java/dwu/swcmop/trippacks/service/FriendService.java
@@ -1,0 +1,86 @@
+package dwu.swcmop.trippacks.service;
+
+import dwu.swcmop.trippacks.config.BaseException;
+import dwu.swcmop.trippacks.dto.FriendRequest;
+import dwu.swcmop.trippacks.dto.FriendResponse;
+import dwu.swcmop.trippacks.entity.Friend;
+import dwu.swcmop.trippacks.entity.User;
+import dwu.swcmop.trippacks.repository.FriendRepository;
+import dwu.swcmop.trippacks.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.transaction.Transactional;
+
+
+import static dwu.swcmop.trippacks.config.BaseResponseStatus.*;
+
+@Service
+public class FriendService {
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private FriendRepository friendRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    public FriendResponse createFriend(FriendRequest friend) throws BaseException {
+        Friend saveFriend = null;
+        User user = null;
+
+        try {
+            Friend newFriend = new Friend(friend.getUserId(), friend.getFriendId(), false);
+            Friend existingFriend = friendRepository.findUserEntityByUserIdAndFriendId(friend.getUserId(), friend.getFriendId());
+
+
+            if (existingFriend == null) {// 이미 저장된 데이터가 없으면 저장
+                user = userRepository.findByUserCode(friend.getFriendId());
+                saveFriend = friendRepository.save(newFriend);
+            } else {
+                throw new BaseException(EXIST_FRIEND_FAIL);
+            }
+        } catch (Exception e) {
+            throw new BaseException(ADD_FRIEND_FAIL);
+        }
+        String userEmail = (user != null) ? user.getKakaoEmail() : null;
+        FriendResponse bagResponse = new FriendResponse(saveFriend.getId(), saveFriend.getUserId(), saveFriend.getFriendId(), userEmail, saveFriend.getIsFriend());
+
+        return bagResponse;
+    }
+
+
+    public int acceptFriend(long Id, long fId) throws BaseException {
+        Friend friend = friendRepository.findUserEntityByUserIdAndFriendId(Id, fId);
+        if (friend == null) {
+            throw new BaseException(FRIEND_IS_EMPTY);
+        }
+
+        friend.setIsFriend(true);//수락
+
+        friendRepository.save(friend);
+
+        return 1;
+    }
+
+
+    @Transactional
+    public int deleteFriend(long Id, long fId) throws BaseException {
+        User user = userService.findById(Id);
+        if (user == null) {
+            throw new BaseException(INVALID_JWT);
+        }
+        Friend getFriend = friendRepository.findUserEntityByUserIdAndFriendId(Id, fId);
+        if (getFriend == null) {
+            throw new BaseException(FRIEND_IS_EMPTY);
+        }
+        try {
+            friendRepository.delete(getFriend);
+        } catch (Exception e) {
+            throw new BaseException(DELETE_FRIEND_FAIL);
+        }
+        return 1;
+    }
+
+}


### PR DESCRIPTION
## 개요
> feat : Friend APi 구현(친구추가/수락/리스트/삭제)

## PR 유형
어떤 변경 사항이 있나요?
- [x] 친구 추가
- [x] 친구 수락
- [x] 친구 리스트
- [x] 친구 삭제

## 주의사항
- [ ] 사용자Id를 사용하는 방식으로 구현하였는데 추후 jwt 인증방식 고려 중...
- [ ] 초대링크 구현은 못함

## 참고자료
<img width="994" alt="image" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/958e3771-165e-4e45-bf5a-21f8e180f74d">

USERCODE기준
ex)userId1 friendID2이면?
**친구 추가**
<img width="1247" alt="스크린샷 2023-10-13 오전 6 25 38" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/ae51f31b-f89d-42d9-8be4-0866b173adb8">
<img width="929" alt="스크린샷 2023-10-13 오전 7 10 39" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/1420eaf5-b956-49af-9f7d-114dadea75a6">

**친구 수락**
친구의 userId1 friendID2기준으로 입력하고 isFriend가 False->True로 바뀜
<img width="709" alt="스크린샷 2023-10-13 오전 6 40 23" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/03498b67-3db7-4f78-b801-2d99844f9ad2">

**친구 리스트**
1의 리스트는 2, 2의 리스트는 1
<img width="713" alt="스크린샷 2023-10-13 오전 6 55 30" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/5787cacd-b86b-4bd6-9940-bc411a7d901c">

**친구 삭제**
1이 삭제해도 2에서 사라지고, 2가 삭제해도 1이 삭제됨
<img width="927" alt="스크린샷 2023-10-13 오전 7 05 59" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/89174f15-aecc-42a7-8c6d-97d7d0d9adee">
