### PR TITLE
fix : invite응답 가방조회

### DIFF
--- a/src/main/java/dwu/swcmop/trippacks/controller/InvitationController.java
+++ b/src/main/java/dwu/swcmop/trippacks/controller/InvitationController.java
@@ -37,6 +37,7 @@ public class InvitationController {
     ) throws BaseException {
         Invitation invitation = invitationService.createOrUpdate((long) request.getBagId());
         InvitationResponse invitationResponse = InvitationMapper.INSTANCE.invitationToInvitationDTO(invitation);
+        invitationResponse.setBagId(Math.toIntExact(invitation.getBag().getBagId()));
 
         BaseResponse<InvitationResponse> response = new BaseResponse<>(invitationResponse);
         return new ResponseEntity<>(response, HttpStatus.OK);
@@ -47,6 +48,7 @@ public class InvitationController {
     public ResponseEntity<BaseResponse<InvitationResponse>> getInvitation(@PathVariable String slug) throws BaseException {
         Invitation invitation = invitationService.findOneBySlug(slug);
         InvitationResponse invitationResponse = InvitationMapper.INSTANCE.invitationToInvitationDTO(invitation);
+        invitationResponse.setBagId(Math.toIntExact(invitation.getBag().getBagId()));
 
         BaseResponse<InvitationResponse> response = new BaseResponse<>(invitationResponse);
         return new ResponseEntity<>(response, HttpStatus.OK);


### PR DESCRIPTION

## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
> invite응답 가방조회 기존에는 출력창에 조회하면 0이 나왔음
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?
- [x] 버그 수정

`/invitations 초대링크 생성
`

<img width="878" alt="스크린샷 2023-10-18 오전 3 14 14" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/68154545-b5e1-4872-b1ec-738c2f649192">


`/invitations/{slug} 초대링크 조회
`


<img width="895" alt="스크린샷 2023-10-18 오전 3 14 07" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/23b15796-1f19-4464-928c-391815c99708">


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).