### PR TITLE
fix : ChatGPT-key전달

### DIFF
--- a/src/main/java/dwu/swcmop/trippacks/config/ChatGptConfig.java
+++ b/src/main/java/dwu/swcmop/trippacks/config/ChatGptConfig.java
@@ -1,13 +1,15 @@
 package dwu.swcmop.trippacks.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
+@Component
 public class ChatGptConfig {
     public static final String AUTHORIZATION = "Authorization";
     public static final String BEARER = "Bearer ";
 
     @Value("${chatGpt.key}")
-    public static String API_KEY; //실행시 원래 api key로 바꾸고, git에 올릴 때에는 임의 값으로 다시 설정!
+    public String API_KEY; //실행시 원래 api key로 바꾸고, git에 올릴 때에는 임의 값으로 다시 설정!
     public static final String MODEL = "text-davinci-003";
     public static final Integer MAX_TOKEN = 300;
     public static final Double TEMPERATURE = 0.0;

--- a/src/main/java/dwu/swcmop/trippacks/service/ChatGptService.java
+++ b/src/main/java/dwu/swcmop/trippacks/service/ChatGptService.java
@@ -4,6 +4,7 @@ import dwu.swcmop.trippacks.config.ChatGptConfig;
 import dwu.swcmop.trippacks.dto.ChatGptRequest;
 import dwu.swcmop.trippacks.dto.ChatGptResponse;
 import dwu.swcmop.trippacks.dto.QuestionRequest;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -15,11 +16,18 @@ import org.springframework.web.client.RestTemplate;
 public class ChatGptService {
 
     private static RestTemplate restTemplate = new RestTemplate();
+    private final ChatGptConfig chatGptConfig;
+
+    @Autowired
+    public ChatGptService(ChatGptConfig chatGptConfig) {
+        this.chatGptConfig = chatGptConfig;
+    }
+
 
     public HttpEntity<ChatGptRequest> buildHttpEntity(ChatGptRequest requestDto) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.parseMediaType(ChatGptConfig.MEDIA_TYPE));
-        headers.add(ChatGptConfig.AUTHORIZATION, ChatGptConfig.BEARER + ChatGptConfig.API_KEY);
+        headers.add(ChatGptConfig.AUTHORIZATION, ChatGptConfig.BEARER + chatGptConfig.API_KEY);
         System.setProperty("https.protocols", "TLSv1.2"); //TLS 버전을 맞추기 위함
         return new HttpEntity<>(requestDto, headers);
     }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
> fix : ChatGPT-key전달

<!---- Resolves: #(Isuue Number) -->
 Resolves: https://github.com/trippack-voyage/voyage-back/issues/43#issue-1944035369

## PR 유형
어떤 변경 사항이 있나요?
- [x] 버그 수정
1. @Value 어노테이션은 인스턴스 변수에 값을 주입하는 데 사용되므로 정적(static) 필드에는 적용할 수 없음
2. 스프링 애플리케이션의 패키지 스캔 설정을 확인하십시오. Spring은 @Component 또는 @Service 어노테이션이 붙은 클래스를 자동으로 검색하고 빈으로 등록합니다. 따라서 ChatGptConfig 클래스가 ChatGptService 클래스와 동일한 패키지 또는 하위 패키지에 있어야 합니다.

<img width="931" alt="스크린샷 2023-10-18 오후 2 45 11" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/e4cc9212-d864-4870-b87c-44d573052aa2">


## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).