### PR TITLE
feat : 짐 요청물품 처리

### DIFF
--- a/src/main/java/dwu/swcmop/trippacks/controller/RequestController.java
+++ b/src/main/java/dwu/swcmop/trippacks/controller/RequestController.java
@@ -1,0 +1,53 @@
+package dwu.swcmop.trippacks.controller;
+
+import dwu.swcmop.trippacks.entity.Request;
+import dwu.swcmop.trippacks.service.RequestService;
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController //(1)
+@RequestMapping("/request")
+public class RequestController {
+
+    private final RequestService requestService;
+
+    @Autowired
+    public RequestController(RequestService requestService) {
+        this.requestService = requestService;
+    }
+
+    @Operation(summary = "짐 요청", description = "친구에게 짐을 요청합니다.")
+    @PostMapping("/create")
+    public Request createRequest(@RequestParam Long fromUserId, @RequestParam Long toFriendId, @RequestParam String requestedProduct) {
+        Request request = new Request();
+        request.setFromUserId(fromUserId);
+        request.setToFriendId(toFriendId);
+        request.setRequestedProduct(requestedProduct);
+        request.setIsOk(false);
+
+        Request createdRequest = requestService.createRequest(request);
+
+        return createdRequest;
+    }
+
+    @Operation(summary = "요청짐 출력", description = "가방주인에게 해당하는 짐 리스트 출력합니다.")
+    @GetMapping("/getRequestsByToFriendId")
+    public List<Request> getRequestsByToFriendId(@RequestParam Long toFriendId) {
+        return requestService.getRequestsByToFriendId(toFriendId);
+    }
+
+    @Operation(summary = "짐 요청 수락", description = "짐Id를 입력받아 짐 요청을 수락합니다.")
+    @PostMapping("/acceptRequest")
+    public Request acceptRequest(@RequestParam Long requestId) {
+        return requestService.acceptRequest(requestId);
+    }
+
+    @Operation(summary = "짐 요청 삭제", description = "짐 요청을 삭제합니다.")
+    @PostMapping("/deleteRequest")
+    public void deleteRequest(@RequestParam Long requestId) {
+        requestService.deleteRequest(requestId);
+    }
+}

--- a/src/main/java/dwu/swcmop/trippacks/entity/Request.java
+++ b/src/main/java/dwu/swcmop/trippacks/entity/Request.java
@@ -1,8 +1,13 @@
 package dwu.swcmop.trippacks.entity;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import javax.persistence.*;
 
 @Entity
+@Getter
+@Setter
 @Table(name = "request")
 public class Request {
     @Id
@@ -10,16 +15,16 @@ public class Request {
     @Column(name = "request_id")
     private Long requestId;
 
-    @ManyToOne
-    @JoinColumn(name = "from_user_id")
-    private User fromUser;
+    @Column(name = "requested_product") // 물품 컬럼의 이름을 명확하게 지정
+    private String requestedProduct;
 
-    @ManyToOne
-    @JoinColumn(name = "to_friend_id")
-    private Friend toFriend;
+    @Column(name = "from_user_id")
+    private Long fromUserId; // User를 Long으로 변경
+
+    @Column(name = "to_friend_id")
+    private Long toFriendId; // Friend를 Long으로 변경
 
     @Column(name = "is_ok")
     private Boolean isOk;
-
 }
 

--- a/src/main/java/dwu/swcmop/trippacks/repository/FriendRepository.java
+++ b/src/main/java/dwu/swcmop/trippacks/repository/FriendRepository.java
@@ -24,4 +24,9 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
     void deleteAllByUserIdOrFriendId(Long userId, Long friendId);
 
+//    List<Friend> findByUserIdAndFriendId(Long userId, Long friendId);
+    @Query("SELECT f FROM Friend f WHERE (f.userId = :userId AND f.friendId = :friendId) OR (f.userId = :friendId AND f.friendId = :userId)")
+    List<Friend> findFriendsWithUserIds(@Param("userId") Long userId, @Param("friendId") Long friendId);
+
+
 }

--- a/src/main/java/dwu/swcmop/trippacks/repository/RequestRepository.java
+++ b/src/main/java/dwu/swcmop/trippacks/repository/RequestRepository.java
@@ -1,0 +1,11 @@
+package dwu.swcmop.trippacks.repository;
+
+import dwu.swcmop.trippacks.entity.Request;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+@Repository
+public interface RequestRepository extends JpaRepository<Request, Long> {
+    List<Request> findByToFriendId(Long toFriendId);
+}

--- a/src/main/java/dwu/swcmop/trippacks/service/RequestService.java
+++ b/src/main/java/dwu/swcmop/trippacks/service/RequestService.java
@@ -1,0 +1,59 @@
+package dwu.swcmop.trippacks.service;
+
+import dwu.swcmop.trippacks.entity.Friend;
+import dwu.swcmop.trippacks.entity.Request;
+import dwu.swcmop.trippacks.repository.FriendRepository;
+import dwu.swcmop.trippacks.repository.RequestRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class RequestService {
+    private final RequestRepository requestRepository;
+    private final FriendRepository friendRepository;
+
+
+    @Autowired
+    public RequestService(RequestRepository requestRepository, FriendRepository friendRepository) {
+        this.requestRepository = requestRepository;
+        this.friendRepository = friendRepository;
+    }
+
+    public Request createRequest(Request request) {
+        List<Friend> friends = friendRepository.findFriendsWithUserIds(request.getFromUserId(), request.getToFriendId());
+
+        if (!friends.isEmpty()) {
+            return requestRepository.save(request);
+        } else {
+            return null; // 친구 아니면
+        }
+    }
+
+    public List<Request> getRequestsByToFriendId(Long toFriendId) {
+        return requestRepository.findByToFriendId(toFriendId);
+    }
+
+    public Request acceptRequest(Long requestId) {
+        Optional<Request> optionalRequest = requestRepository.findById(requestId);
+
+        if (optionalRequest.isPresent()) {
+            Request request = optionalRequest.get();
+            request.setIsOk(true); // 수락하면 isOk를 true로 설정
+            return requestRepository.save(request);
+        } else {
+            return null;// 요청이 존재하지 않음을 처리
+        }
+    }
+
+    public void deleteRequest(Long requestId) {
+        Optional<Request> optionalRequest = requestRepository.findById(requestId);
+        if (optionalRequest.isPresent()) {
+            requestRepository.delete(optionalRequest.get());
+        } else {
+            // 요청이 존재하지 않음을 처리
+        }
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
> feat : 짐 요청물품
<!---- Resolves: #(Isuue Number) -->
Resolves: https://github.com/trippack-voyage/voyage-back/issues/57#issue-1950220929
## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
`짐 요청`
`짐 요청 수락`
`짐 요청 삭제`
`짐 요청 출력`
<img width="980" alt="image" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/2de2f9eb-5b91-4d58-9fe7-1e17ad8dc40d">

**💫프론트에게 전달: 짐 요청은 초대링크로 가방에 접근합니다**
 링크초대(가방ID획득)->가방조회API(가방ID로 조회)->물품요청API
## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).## Description

**짐 요청 API**
<img width="923" alt="스크린샷 2023-10-19 오전 12 06 54" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/a936ac59-e267-4306-8456-83c3a2738c07">
<img width="912" alt="스크린샷 2023-10-19 오전 12 07 01" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/24f8cd82-6914-4d64-ab1d-ad7cfd0f9ac5">

**짐 요청 수락API**
 수락하면 table true로 변경 
**💫프론트에게 전달:  즉, false면  수락버튼, true면 아무 것도 안 보이게 프론트에서 처리**
<img width="735" alt="image" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/5a174d51-c5fd-4976-a923-6bfd921f15ea">

**짐 요청 삭제API**
<img width="749" alt="image" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/b4ecff25-82ee-45a5-ba1e-26dff5ecc8e5">

**짐 요청 출력API**
<img width="924" alt="스크린샷 2023-10-19 오전 12 07 26" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/2a4c09bf-4dc0-4f11-b767-e1db0667895b">
<img width="921" alt="스크린샷 2023-10-19 오전 12 14 22" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/14227793-b298-48dd-8eac-bdfe94d2aa8f">

**로직 처리**
- [x] fromuser가 상대방 tofriend에게 물품요청하면(물품 컬럼 추가해야될듯) 
- [x] 요청하기 가방id,(가방주인아님)Id, fid(가방주인), 물품 입력
 **💫요청시 (id fid로친구테이블 따로 검증하자)**
 "fromUserId"와 "friendId"가 같고 "toFriendId"와 "userId"가 동일한 경우를 검증하는 코드를 작성
