### PR TITLE
fix : weather-react 연동

### DIFF
--- a/src/main/java/dwu/swcmop/trippacks/controller/WeatherController.java
+++ b/src/main/java/dwu/swcmop/trippacks/controller/WeatherController.java
@@ -4,9 +4,13 @@ import dwu.swcmop.trippacks.dto.Weather;
 import dwu.swcmop.trippacks.service.WeatherService;
 import lombok.AllArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @AllArgsConstructor
@@ -15,10 +19,24 @@ public class WeatherController {
     private final WeatherService weatherService;
 
     //도시별 날씨 조회
+//    @GetMapping("/weather")
+//    public Weather createDiary(@RequestBody String city){
+//        return weatherService.createDiary(city);
+//    }
+//
+    //도시별 날씨 조회
     @GetMapping("/weather")
-    public Weather createDiary(@RequestBody String city){
-        return weatherService.createDiary(city);
-    }
+    public ResponseEntity<?> createDiary(@RequestParam String city) {
+        Weather weather = weatherService.createDiary(city);
 
+        if (weather != null) {
+            Map<String, Object> response = new HashMap<>();
+            response.put("weather", weather.getWeather());
+            response.put("temperature", weather.getTemperature());
+            return new ResponseEntity<>(response, HttpStatus.OK);
+        } else {
+            return new ResponseEntity<>("Weather data not found", HttpStatus.NOT_FOUND);
+        }
+    }
 
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
> fix : weather-react 연동
<!---- Resolves: #(Isuue Number) -->
Resolves: https://github.com/trippack-voyage/voyage-back/issues/43#issue-1944035369

## PR 유형
어떤 변경 사항이 있나요?
- [x] 코드 리팩토링
- [x] 문서 수정
> React에서 axios를 사용하여 GET 요청을 보낼 때, GET 요청의 바디에 데이터를 넣는 것은 일반적으로 지원되지 않습니다. GET 요청은 주로 쿼리 문자열을 사용하여 데이터를 전달합니다. 따라서 Spring 컨트롤러의 createDiary 메서드에서 요청 바디에서 데이터를 읽으려고 시도하면 오류가 발생합니다.
String 컨트롤러의 createDiary 메서드를 수정하여 요청 파라미터로 데이터를 읽습니다:

<img width="896" alt="image" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/7f12c286-6c97-4cbd-89fb-d42b7ad4ba2f">
<img width="540" alt="스크린샷 2023-10-22 오전 5 48 02" <img width="545" alt="스크린샷 2023-10-22 오전 5 48 09" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/2b0b2704-3347-4c1a-a71b-28e202c17049">

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).