### PR TITLE
fix : usecode로 사용자조회(nmae,profile)

### DIFF
--- a/src/main/java/dwu/swcmop/trippacks/controller/LoginController.java
+++ b/src/main/java/dwu/swcmop/trippacks/controller/LoginController.java
@@ -15,7 +15,10 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static dwu.swcmop.trippacks.config.BaseResponseStatus.INVALID_USER;
 
@@ -78,16 +81,20 @@ public class LoginController {
 
     @ApiOperation(value = "UserCode로 사용자 조회", notes = "사용자Id로 사용자정보 조회")
     @GetMapping("find/{userId}")
-    public BaseResponse<String> getUser(@PathVariable("userId") Long id) {
+    public ResponseEntity<Map<String, String>> getUser(@PathVariable("userId") Long id) {
 
         try {
-            String user = String.valueOf(userService.findById(id));
+            User user = userService.findById(id);
 
-            if (userService.findById(id) == null) {
-                return new BaseResponse<>(INVALID_USER);
+            if (user == null) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Collections.singletonMap("result", "User not found"));
             }
 
-            return new BaseResponse<>(user);
+            Map<String, String> result = new HashMap<>();
+            result.put("kakaoNickname", user.getKakaoNickname());
+            result.put("kakaoProfileImg", user.getKakaoProfileImg());
+
+            return ResponseEntity.ok(result);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?
> fix : usecode로 사용자조회(nmae,profile)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [x] 문서 수정

userCode로 사용자가 조회되긴하는데 string값으로 넘어와서 kakaoNickName하고 프로필만 추출을 못함. 배열로 바꾸면 [] 식으로 묶어서 전송 원함

`전`
<img width="388" alt="image" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/eb46753b-f908-4d5f-82f8-8144f70aee08">
`후`
<img width="619" alt="스크린샷 2023-10-24 오후 3 00 22" src="https://github.com/trippack-voyage/voyage-back/assets/94455716/6f96f6a7-7d2f-4c9f-867a-5eff7bc7fbfc">

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).