### PR TITLE
feat : TripInfo여행정보필터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 
 	//json
 	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.0' // 현재 Jackson 버전으로 업데이트
+
 
 	//mapper
 	implementation 'org.mapstruct:mapstruct:1.5.5.Final'

--- a/src/main/java/dwu/swcmop/trippacks/dto/TripInfo.java
+++ b/src/main/java/dwu/swcmop/trippacks/dto/TripInfo.java
@@ -1,0 +1,19 @@
+package dwu.swcmop.trippacks.dto;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+public class TripInfo {
+    private int numberOfLocations;
+    private int totalTripDuration;
+    private List<String> uniqueLocations;
+
+    public TripInfo(int numberOfLocations, int totalTripDuration, List<String> uniqueLocations) {
+        this.numberOfLocations = numberOfLocations;
+        this.totalTripDuration = totalTripDuration;
+        this.uniqueLocations = uniqueLocations;
+    }
+}


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
**[여행 정보 추가]
feat : TripInfo** 
```
개의 여행 ex) 4개 도시여행
총 여행기간 ex) 총 30일의 여행
여행지 리스트 ex)서울,부산, 대구
```

<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?
새로운 기능 추가
- [x] (개의 여행) location정보로가 같은 이름은 개수 포함하지 않고(중복제거)  몇 개인지 출력 ,
- [x] (총 여행기간)총 여행기간  endData startData의 차 + 1 후  총 합
- [x] (여행지 리스트) location정보를 리스트로 출력해주는데 같은 이름은 한 번만 출력되게

## 해결방안
*에러*
TripInfo 객체를 JSON 형식으로 응답으로 변환하는 데 필요한 변환기(converter)를 찾을 수 없다는 에러
DefaultHandlerExceptionResolver : Resolved [org.springframework.http.converter.HttpMessageNotWritableException: No converter for [class dwu.swcmop.trippacks.dto.TripInfo] with preset Content-Type 'null']


**해결방법1. 직렬화 처리**
```
import com.fasterxml.jackson.annotation.JsonIgnoreProperties;

@JsonIgnoreProperties(ignoreUnknown = true)
public class TripInfo {
    // ... 클래스 멤버 및 생성자
}

```
**해결방법2. Jackson은 getter 메서드**
TripInfo 클래스의 필드에 대한 getNumberOfLocations(), getTotalTripDuration(), getUniqueLocations()와 같은 getter 메서드가 있어야 합니다. Jackson은 getter 메서드를 사용하여 필드 값을 직렬화합니다.

**해결방법3. null값 체크**
java.text.SimpleDateFormat.parse 메서드를 호출할 때 발생하는 NullPointerException 오류는 날짜 형식이 잘못된 경우 또는 null 값을 처리하지 않았을 때 발생할 수 있습니다

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
|기능| 스크린샷|
|----------|--------|
|여행정보-지영|<img width="609" alt="스크린샷 2023-11-08 오전 1 27 04" src="https://github.com/lakedata/voyage-back/assets/94455716/bfc5f4de-458f-4e3e-921e-a8cc42ed5a98">|
|여행정보-미지|<img width="605" alt="스크린샷 2023-11-08 오전 1 27 21" src="https://github.com/lakedata/voyage-back/assets/94455716/0af5155f-b14b-49d6-8161-d18e8881a752">|
|여행정보-혜연|<img width="593" alt="스크린샷 2023-11-08 오전 1 27 29" src="https://github.com/lakedata/voyage-back/assets/94455716/243bc58e-58e0-46a7-bfdc-a06757b14a74">|

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).